### PR TITLE
Fix pasting error in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Select Other
 Often times a select field on a website will give inefficient options when they allow you to input any 'other' option. Typically a new input field will appear, or a constant input field will be there, only to be used when 'other' is selected.
 
-The solution for this is Select Other, a jQuery plugin that allows dropdown select field to transform into input fields on command!
+The solution for this is Select Other, a jQuery plugin that allows dropdown select field to transform into input field on command!
 
 ### [DEMO](https://petersonryan.com/projects/select-other/)
 
@@ -9,7 +9,7 @@ The solution for this is Select Other, a jQuery plugin that allows dropdown sele
 ```html
 <!-- Dependencies -->
 <script src="jQuery.js"></script>
-<!-- Proper Anchor -->
+<!-- Select Other -->
 <script src="dist/select-other.js"></script>
 <link href="dist/select-other.css" rel="stylesheet"/>
 <script>


### PR DESCRIPTION
1. Other project name seems to be copied accidentally as part of the comment, edited to use current project's name instead ('Proper Anchor' -> 'Select Other') 
2. Transform to 1 input field ('fields' -> 'field')